### PR TITLE
Item scroll adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repo contains a list of input binding overrides that can be used to make di
 | `wmr`             | @CH3k                                    | This just adds support for WMR remotes, jump is bound to right touchpad, Drop Item is bound to left touchpad         |
 | `index_touchpads` | [@Bontebok](https://github.com/Bontebok) | For Index controllers, prevents joystick damage. Sprint left grip, crouch left touchpad, secondary right touchpad.   |
 | `htc_vive`        | @KYRIS0                                  | This adds support for vive controller, jump is bound to left trigger                                                 |
+| `item_scroll_deadzone` | @donko526 | Default profile w/ altered R-stick item scroll behavior. Less sensative and switch on tap.   |
 
 # Applying a custom profile
 

--- a/item_scroll_deadzone/lcvr_lc_inputs.json
+++ b/item_scroll_deadzone/lcvr_lc_inputs.json
@@ -1,0 +1,1105 @@
+{
+  "name": "PlayerActions",
+  "maps": [
+    {
+      "name": "Movement",
+      "id": "1560e87b-23aa-4005-bf8b-264f6a3c3736",
+      "actions": [
+        {
+          "name": "Look",
+          "type": "Value",
+          "id": "c63a6ade-6c5a-4659-9aa5-e336e7b9970f",
+          "expectedControlType": "Vector2",
+          "processors": "AxisDeadzone(max=1)",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Move",
+          "type": "Value",
+          "id": "1af759ec-380d-4f9b-9108-c4e024e17c3e",
+          "expectedControlType": "Vector2",
+          "processors": "AxisDeadzone(min=0.3,max=1)",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Jump",
+          "type": "Button",
+          "id": "29820219-83ac-41cb-9f43-9ba2bcb7882c",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Sprint",
+          "type": "Value",
+          "id": "38a90280-ca06-4012-853a-06cd9bf6cda3",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "OpenMenu",
+          "type": "Button",
+          "id": "61f99167-dec0-46cb-a700-a21e900ddbe6",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Interact",
+          "type": "Value",
+          "id": "7dc7e4c4-a4eb-449d-a885-cf7ad4b8faaa",
+          "expectedControlType": "",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Crouch",
+          "type": "Button",
+          "id": "a5e81f24-9799-4b3e-b009-386c60e18cc1",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Use",
+          "type": "Button",
+          "id": "afa10779-50c6-45ee-828e-2c782fd48921",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "ActivateItem",
+          "type": "Button",
+          "id": "990dbbff-3266-4890-8b7d-da5d76679e09",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Discard",
+          "type": "Button",
+          "id": "a4608dd4-03c1-4f59-94e2-84a333a9981b",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "SwitchItem",
+          "type": "Value",
+          "id": "c4f37a56-2df5-447b-8d60-98946d41bfe8",
+          "expectedControlType": "",
+          "processors": "AxisDeadzone",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "QEItemInteract",
+          "type": "Value",
+          "id": "e1790f23-249a-40a3-b51b-892fd6eb78d4",
+          "expectedControlType": "Axis",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "EnableChat",
+          "type": "Button",
+          "id": "58e1c009-b16f-4d4d-a0ee-1d2922c4a10f",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "SubmitChat",
+          "type": "Button",
+          "id": "52ce15c0-45ed-4b05-98ed-04db00b51b35",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "ReloadBatteries",
+          "type": "Button",
+          "id": "2f6bf1bd-1a9d-42de-bab3-345b343c4010",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "SetFreeCamera",
+          "type": "Button",
+          "id": "f783bb29-6cc7-46ae-b08c-b5ec213df236",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "InspectItem",
+          "type": "Button",
+          "id": "d22b85a2-31df-40ce-b54f-ef936324a412",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "SpeedCheat",
+          "type": "Button",
+          "id": "1f917a99-4119-46b5-9cd3-a306bd7f7d4a",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "PingScan",
+          "type": "Button",
+          "id": "10a87310-b590-4c4a-bb17-c6e801480dee",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "VoiceButton",
+          "type": "Value",
+          "id": "c0b6b3e8-4fe6-46b7-896a-0e8e1f39bcff",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Emote1",
+          "type": "Button",
+          "id": "c6fba331-7cf2-4fd9-a214-f95c9182cb92",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Emote2",
+          "type": "Button",
+          "id": "02446a15-cc51-421a-8cde-feca90b28c42",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "BuildMode",
+          "type": "Button",
+          "id": "31bb1483-6a93-4220-9542-6483a33469bd",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "ConfirmBuildMode",
+          "type": "Button",
+          "id": "995cf773-e209-4596-b873-0ef4652542f1",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Delete",
+          "type": "Button",
+          "id": "c3fbd8b5-4e95-4a60-ae3a-907c2af57784",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "ItemSecondaryUse",
+          "type": "Button",
+          "id": "8ae96c08-d354-4049-91f2-43523afc18fb",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "ItemTertiaryUse",
+          "type": "Button",
+          "id": "980fdb3c-d831-4f7b-b159-ef1cda9c026a",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        }
+      ],
+      "bindings": [
+        {
+          "name": "Movement: Left Joystick",
+          "id": "efe1ca7a-482c-4dfb-b80b-a34166b2cc7d",
+          "path": "<XRController>{LeftHand}/Primary2DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Jump: A",
+          "id": "29d0e539-abdc-46ae-8dff-27436261f379",
+          "path": "<XRController>{RightHand}/primaryButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Jump",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Sprint: Left Joystick Click",
+          "id": "c243b846-2159-41a2-87d5-5a36f89e70da",
+          "path": "<XRController>{LeftHand}/{Primary2DAxisClick}",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Sprint",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Open menu: X",
+          "id": "b73f442d-bbd4-45ad-87d5-34cba090fa9b",
+          "path": "<XRController>{LeftHand}/primaryButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "OpenMenu",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Interact: Right Grip Button",
+          "id": "a7e5a03c-3ab7-45be-970a-a9c2963502fc",
+          "path": "<XRController>{RightHand}/gripButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Interact",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Crouch: Right Joystick Click",
+          "id": "e3c54809-7fb3-4bc6-9aed-40a36b018c06",
+          "path": "<XRController>{RightHand}/{Primary2DAxisClick}",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Crouch",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Use: Right Trigger",
+          "id": "73118618-851a-4995-8aae-3848f6f81ab5",
+          "path": "<XRController>{RightHand}/trigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Use",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Activate Item: Right Trigger",
+          "id": "15a2f703-29f3-46b5-a1d0-508a159aad30",
+          "path": "<XRController>{RightHand}/trigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ActivateItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Discard: B",
+          "id": "99c75319-4397-4e28-9316-fedfd1c63c1c",
+          "path": "<XRController>{RightHand}/secondaryButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Discard",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Switch Item: Right Joystick Y",
+          "id": "2d8f3396-cbb0-401e-8751-38cc079ff90e",
+          "path": "<XRController>{RightHand}/primary2DAxis/y",
+          "interactions": "tap",
+          "processors": "stickDeadzone(min=0.9,max=1)",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Ping Scan: Left Trigger Button",
+          "id": "82b7c0d0-3d7c-4b80-acf2-17e66cf5b3ac",
+          "path": "<XRController>{LeftHand}/trigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "PingScan",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Secondary Use: Left Grip Button",
+          "id": "98208326-0c62-44ca-8a9c-7d2040e8ef05",
+          "path": "<XRController>{LeftHand}/gripButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemSecondaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Tertiary Use: Right Grip Button",
+          "id": "92390ba9-1945-4659-abce-9b00cba8fb4b",
+          "path": "<XRController>{RightHand}/gripButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemTertiaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+
+        {
+          "name": "",
+          "id": "7aea34a9-040b-4a60-b98a-ef8cb75e8ccf",
+          "path": "<Mouse>/delta",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Look",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "171607bb-692f-4770-9f45-05b1456f6ce0",
+          "path": "<Gamepad>/rightStick",
+          "interactions": "",
+          "processors": "ScaleVector2(x=70,y=70)",
+          "groups": "",
+          "action": "Look",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Keyboard",
+          "id": "efe1ca7a-482c-4dfb-b80b-a34166b2cc7d",
+          "path": "2DVector",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "up",
+          "id": "ae3df94a-dcc6-4177-b026-0938f8413a45",
+          "path": "<Keyboard>/w",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "down",
+          "id": "bc252037-120e-4c64-9671-40d365f856b3",
+          "path": "<Keyboard>/s",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "left",
+          "id": "ad96b1ce-c0f3-4913-be03-acf077c11064",
+          "path": "<Keyboard>/a",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "right",
+          "id": "756f3db2-a6e6-42d7-9580-70d42154cd11",
+          "path": "<Keyboard>/d",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "Gamepad",
+          "id": "cf7c5308-2d64-47a4-905b-9eea531e7b39",
+          "path": "2DVector",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "up",
+          "id": "bb6e2ec9-7f02-4c1e-b136-f45218f65d48",
+          "path": "<Gamepad>/leftStick/up",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "down",
+          "id": "717338d1-0b10-457a-a2ef-9b43135cbad6",
+          "path": "<Gamepad>/leftStick/down",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "left",
+          "id": "1ffdc730-e9c8-4a8a-934f-98fa19bdca4d",
+          "path": "<Gamepad>/leftStick/left",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "right",
+          "id": "bc814a6c-e505-4ad6-988b-8e9ce3311a28",
+          "path": "<Gamepad>/leftStick/right",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Move",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "",
+          "id": "29d0e539-abdc-46ae-8dff-27436261f379",
+          "path": "<Keyboard>/space",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Jump",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "7b616c75-7032-463c-b9d3-72884bcded84",
+          "path": "<Gamepad>/buttonSouth",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Jump",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "c243b846-2159-41a2-87d5-5a36f89e70da",
+          "path": "<Keyboard>/shift",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Sprint",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "ea358e03-6f7e-4054-860f-ded39d00cc30",
+          "path": "<Gamepad>/leftTrigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Sprint",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "00fb2c2d-6f7a-498b-91a9-42c3ead2d5f3",
+          "path": "<Keyboard>/escape",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "OpenMenu",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "b73f442d-bbd4-45ad-87d5-34cba090fa9b",
+          "path": "<Gamepad>/start",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "OpenMenu",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "3d52b957-c79a-4d3f-b84c-a0f21cf4c089",
+          "path": "<Keyboard>/tab",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "OpenMenu",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "155d449f-a2c5-43ab-9244-955fec5e0497",
+          "path": "<Keyboard>/e",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Interact",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "a7e5a03c-3ab7-45be-970a-a9c2963502fc",
+          "path": "<Gamepad>/buttonWest",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Interact",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "3bfe566d-e645-4254-8fd2-2c98358dbd17",
+          "path": "<Keyboard>/ctrl",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Crouch",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "e3c54809-7fb3-4bc6-9aed-40a36b018c06",
+          "path": "<Gamepad>/rightStickPress",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Crouch",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "9e5d8c19-ecee-48ed-ac7f-039528c22031",
+          "path": "<Mouse>/leftButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Use",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "73118618-851a-4995-8aae-3848f6f81ab5",
+          "path": "<Gamepad>/rightTrigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Use",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "19548cb7-6c57-4972-a4e3-28a4e7e71595",
+          "path": "<Mouse>/leftButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ActivateItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "15a2f703-29f3-46b5-a1d0-508a159aad30",
+          "path": "<Gamepad>/rightTrigger",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ActivateItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "c3c0f7fa-24e9-49bc-9e71-0405fdd4cf02",
+          "path": "<Keyboard>/g",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Discard",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "99c75319-4397-4e28-9316-fedfd1c63c1c",
+          "path": "<Gamepad>/buttonEast",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Discard",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "Keyboard",
+          "id": "8b556e1d-3fa1-4bf0-b121-141c72a65a57",
+          "path": "1DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "positive",
+          "id": "2d8f3396-cbb0-401e-8751-38cc079ff90e",
+          "path": "<Mouse>/scroll/up",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "negative",
+          "id": "fb0b095c-497a-4c00-b02f-742282882d16",
+          "path": "<Mouse>/scroll/down",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "Gamepad",
+          "id": "1c0126ca-90ce-44ce-bd72-2b8c360c6878",
+          "path": "1DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "negative",
+          "id": "e78e4bd2-197c-4efc-9d25-591099baed01",
+          "path": "<Gamepad>/dpad/left",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "positive",
+          "id": "b8495d4f-06e7-4c2d-9779-64b5a929acf4",
+          "path": "<Gamepad>/dpad/right",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SwitchItem",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "1D Axis",
+          "id": "a7b0da01-86be-4854-b134-176d96ab1571",
+          "path": "1DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "negative",
+          "id": "c62b6b31-53c1-43f9-92c5-07f7217c585e",
+          "path": "<Keyboard>/q",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "positive",
+          "id": "8f47af30-c4b4-4448-bd39-d9aba47a3188",
+          "path": "<Keyboard>/e",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "1D Axis",
+          "id": "a307f844-0fa2-4111-b60a-afd91de8e536",
+          "path": "1DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": true,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "negative",
+          "id": "7b008b4a-fdb1-4603-becb-6b90ee9e345c",
+          "path": "<Gamepad>/dpad/down",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "positive",
+          "id": "86e38089-e357-45c5-a39d-7d66cdcbf803",
+          "path": "<Gamepad>/dpad/up",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "QEItemInteract",
+          "isComposite": false,
+          "isPartOfComposite": true
+        },
+        {
+          "name": "",
+          "id": "e8ff5cf5-ee6d-4e54-a800-27c16bf307fc",
+          "path": "<Keyboard>/slash",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "EnableChat",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "e6fe9b9c-ff67-4d42-83b9-979bfb1623df",
+          "path": "<Keyboard>/enter",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SubmitChat",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "91068d88-dacd-4f4e-8d78-b360b12c8f99",
+          "path": "<Keyboard>/r",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ReloadBatteries",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "48a42f6b-7cb1-4f49-bc47-03628a21a652",
+          "path": "<Keyboard>/c",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SetFreeCamera",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "9a7b1df9-3829-42d5-967d-bf7cb202d823",
+          "path": "<Gamepad>/select",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SetFreeCamera",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "e2f85d45-4161-43dd-9792-9655d4ffb7fe",
+          "path": "<Keyboard>/z",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "InspectItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "e81e7228-432d-4b23-b2bc-c4adcce2f830",
+          "path": "<Gamepad>/leftShoulder",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "InspectItem",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "351e9484-e505-4183-ba21-c666bd64484e",
+          "path": "<Keyboard>/h",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "SpeedCheat",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "f41287a6-fe38-4620-a1ec-b4d871a72d17",
+          "path": "<Mouse>/rightButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "PingScan",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "82b7c0d0-3d7c-4b80-acf2-17e66cf5b3ac",
+          "path": "<Gamepad>/rightShoulder",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "PingScan",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "654df1e4-2b33-44e0-afdb-b57dcce462a5",
+          "path": "<Keyboard>/t",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "VoiceButton",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "8c5fe1cb-4346-4fe7-a829-2f6af2459ed2",
+          "path": "<Keyboard>/1",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Emote1",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "688e42e4-2fc3-406c-96c4-8ed5dbdd96e0",
+          "path": "",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Emote1",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "84dee523-67bb-4220-bf80-3d770065c31b",
+          "path": "<Keyboard>/2",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Emote2",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "1cb11df6-1d3c-4853-a0b3-81bb4524346c",
+          "path": "",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Emote2",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "b64c453d-9f9e-462f-9227-51307bcab6ed",
+          "path": "<Keyboard>/b",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "BuildMode",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "a7abfd96-3670-4488-80ec-1f1d13b99cfc",
+          "path": "<Gamepad>/buttonNorth",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "BuildMode",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "9373b4dc-553a-4526-89c9-f36926194964",
+          "path": "<Keyboard>/v",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ConfirmBuildMode",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "e2f369bc-1ae3-4dcb-837e-e6a2e7c37e5e",
+          "path": "<Keyboard>/x",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Delete",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "788e33f1-366b-4eb0-b1ed-ebc6dcaaaa21",
+          "path": "<Keyboard>/q",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemSecondaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "98208326-0c62-44ca-8a9c-7d2040e8ef05",
+          "path": "<Gamepad>/dpad/down",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemSecondaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "d0787104-91af-4c01-ae46-b9150232edb6",
+          "path": "<Keyboard>/e",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemTertiaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "92390ba9-1945-4659-abce-9b00cba8fb4b",
+          "path": "<Gamepad>/dpad/up",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "ItemTertiaryUse",
+          "isComposite": false,
+          "isPartOfComposite": false
+        }
+      ]
+    }
+  ],
+  "controlSchemes": []
+}

--- a/item_scroll_deadzone/lcvr_vr_inputs.json
+++ b/item_scroll_deadzone/lcvr_vr_inputs.json
@@ -1,0 +1,338 @@
+{
+  "name": "VR",
+  "maps": [
+    {
+      "name": "Head",
+      "id": "7f3d9a5f-aadc-4a0b-9b79-b32e1b5afa1c",
+      "actions": [
+        {
+          "name": "Position",
+          "type": "Value",
+          "id": "3bbc2aad-20de-4984-9d68-83cb6f68ce5b",
+          "expectedControlType": "Vector3",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Rotation",
+          "type": "Value",
+          "id": "ab87d7f3-9e8b-4dd2-9ee2-7a65a4824cd7",
+          "expectedControlType": "Quaternion",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Tracking State",
+          "type": "Value",
+          "id": "8f8f9895-b507-4e6d-9f7b-7394bb6a8875",
+          "expectedControlType": "Integer",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        }
+      ],
+      "bindings": [
+        {
+          "name": "",
+          "id": "f386a081-1246-470b-84d2-3f42674c2aa7",
+          "path": "<XRHMD>/centerEyePosition",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Position",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "0a5b8eb3-4ec1-405a-a60d-f54ac1e176a4",
+          "path": "<XRHMD>/centerEyeRotation",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Rotation",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "47e4ebef-c948-4461-8d37-e13ab1df6d75",
+          "path": "<XRHMD>/trackingState",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Tracking State",
+          "isComposite": false,
+          "isPartOfComposite": false
+        }
+      ]
+    },
+    {
+      "name": "Right Hand",
+      "id": "65f3cab3-6216-4322-9ae2-1d8cc94aec75",
+      "actions": [
+        {
+          "name": "Position",
+          "type": "Value",
+          "id": "0cb2f8b7-9cb6-4cfd-b3d7-b1ce78d3c145",
+          "expectedControlType": "Vector3",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Rotation",
+          "type": "Value",
+          "id": "14425d0d-c38a-47bc-9fa4-47b1ffa6d012",
+          "expectedControlType": "Quaternion",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Tracking State",
+          "type": "Value",
+          "id": "c211352d-ea08-440f-8889-54b1d4e45b52",
+          "expectedControlType": "Integer",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Thumbstick",
+          "type": "Value",
+          "id": "53aec57a-4171-4fab-80b9-ae5d9be70ef8",
+          "expectedControlType": "Vector2",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        }
+      ],
+      "bindings": [
+        {
+          "name": "",
+          "id": "3d220f63-87b7-4446-b44a-8168792d1ad1",
+          "path": "<XRController>{RightHand}/deviceRotation",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Rotation",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "a02539f1-2661-4485-beac-02c33aba5ae6",
+          "path": "<XRController>{RightHand}/devicePosition",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Position",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "9254202a-6b01-464d-a7a5-f51885d9c085",
+          "path": "<XRController>{RightHand}/trackingState",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Tracking State",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "7d25153a-ad46-4992-9593-bd3f9e8c1348",
+          "path": "<XRController>{RightHand}/primary2DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Thumbstick",
+          "isComposite": false,
+          "isPartOfComposite": false
+        }
+      ]
+    },
+    {
+      "name": "Left Hand",
+      "id": "63137698-8838-4387-a83b-214e657cf8a0",
+      "actions": [
+        {
+          "name": "Position",
+          "type": "Value",
+          "id": "d1cfe040-4e61-4dac-bace-0fab746eec9a",
+          "expectedControlType": "Vector3",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Rotation",
+          "type": "Value",
+          "id": "b50185e8-ec70-4285-ae94-ccb0d361f018",
+          "expectedControlType": "Quaternion",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Tracking State",
+          "type": "Value",
+          "id": "f2cac2dc-317e-45d6-bb54-10d8339c8c4a",
+          "expectedControlType": "Integer",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        }
+      ],
+      "bindings": [
+        {
+          "name": "",
+          "id": "ed4c47be-53c6-4ddc-bde8-309c31a1cf24",
+          "path": "<XRController>{LeftHand}/deviceRotation",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Rotation",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "93939c9d-cbba-4101-875d-8e14f94f03fa",
+          "path": "<XRController>{LeftHand}/devicePosition",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Position",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "53d61bc8-ee9b-4aba-b026-6a14c3497afd",
+          "path": "<XRController>{LeftHand}/trackingState",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Tracking State",
+          "isComposite": false,
+          "isPartOfComposite": false
+        }
+      ]
+    },
+    {
+      "name": "Controls",
+      "id": "df95fc4d-7a68-43de-bf28-767daddc38b4",
+      "actions": [
+        {
+          "name": "Reset Height",
+          "type": "Button",
+          "id": "3a6fafda-15fb-48b1-8b6c-395fe53ca8db",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Grab",
+          "type": "Button",
+          "id": "b1b09523-8b94-4914-92c1-8f219cf52d9d",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        },
+        {
+          "name": "Turn",
+          "type": "Value",
+          "id": "9bba4c2e-5864-40dd-9358-cf22cb989178",
+          "expectedControlType": "Axis",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Pivot",
+          "type": "Value",
+          "id": "8b4448cc-928b-4e90-8b85-0376dbdede65",
+          "expectedControlType": "Vector2",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": true
+        },
+        {
+          "name": "Sprint",
+          "type": "Button",
+          "id": "466ecbb6-9528-4ed2-8935-10754d3bbabb",
+          "expectedControlType": "Button",
+          "processors": "",
+          "interactions": "",
+          "initialStateCheck": false
+        }
+      ],
+      "bindings": [
+        {
+          "name": "",
+          "id": "b3c1f575-6801-423a-9493-d928349ee025",
+          "path": "<XRController>{LeftHand}/secondaryButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Reset Height",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "8ada7364-58e2-413f-83ce-0a04ce997082",
+          "path": "<XRController>{RightHand}/gripButton",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Grab",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "c39025cf-5de2-4790-9d7a-8618b1e97743",
+          "path": "<XRController>{RightHand}/primary2DAxis/x",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Turn",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "654fc1be-7486-4b83-ab97-1a3fcc3cdb60",
+          "path": "<XRController>{RightHand}/primary2DAxis",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Pivot",
+          "isComposite": false,
+          "isPartOfComposite": false
+        },
+        {
+          "name": "",
+          "id": "91f06119-90cf-47d2-af1f-d646743ba392",
+          "path": "<XRController>{LeftHand}/{Primary2DAxisClick}",
+          "interactions": "",
+          "processors": "",
+          "groups": "",
+          "action": "Sprint",
+          "isComposite": false,
+          "isPartOfComposite": false
+        }
+      ]
+    }
+  ],
+  "controlSchemes": []
+}


### PR DESCRIPTION
The default profile's item scroll was incredibly sensitive on Quest 2. I altered the behavior so that the R-stick y-axis has a deadzone and items switch on tap release.